### PR TITLE
Custom delete with cloudlet activation on production

### DIFF
--- a/bin/akamai-onboard.py
+++ b/bin/akamai-onboard.py
@@ -1259,7 +1259,7 @@ def custom_delete(config, **kwargs):
         uc = utility.Cloudlets(config)
         uc.retrieve_matchrules(onboard.cloudlet_policy)
         cloudlet_rules = load_json('policy_matchrules.json')
-
+        #logger.info(f'cloudlet_rules: {cloudlet_rules}')
         if not cloudlet_rules:
             logger.error("❌ Failed to load cloudlet_rules from policy_matchrules.json")
             return
@@ -1279,10 +1279,20 @@ def custom_delete(config, **kwargs):
                 updated_rules["matchRules"],
                 onboard.version_notes
             )
-            uc.activate_policy(onboard, version_number, network='STAGING')
-            uc.activate_policy(onboard, version_number, network='PRODUCTION')
+            #uc.activate_policy_for_customdelete(onboard, version_number, network='STAGING')
+            #uc.activate_policy_for_customdelete(onboard, version_number, network='PRODUCTION')
+
+            if onboard.activate_cloudlet_staging:
+                uc.activate_policy_for_customdelete(onboard, version_number, network='STAGING')
+            else:
+                logger.warning('SKIP - Activate cloudlet config on STAGING')
+
+            if onboard.activate_cloudlet_production:
+                uc.activate_policy_for_customdelete(onboard, version_number, network='PRODUCTION')
+            else:
+                logger.warning('SKIP - Activate cloudlet config on PRODUCTION')
         else:
-            logger.warning('No cloudlet paths removed or no update needed')
+            logger.warning('No cloudlet paths removed or no update needed')   
 
     end_time = time.perf_counter()
     elapse_time = str(strftime('%H:%M:%S', gmtime(end_time - start_time)))

--- a/bin/utility.py
+++ b/bin/utility.py
@@ -2030,6 +2030,29 @@ class Cloudlets:
             stdout, stderr = act_cloudlet_cli.communicate()
             print(stdout.decode('utf-8'))
 
+    def activate_policy_for_customdelete(self, onboard, version: int, network: str):
+        activation = False
+        if network == 'STAGING':
+            activation = onboard.activate_cloudlet_staging
+        if network == 'PRODUCTION':
+            activation = onboard.activate_cloudlet_production
+
+        if not activation:
+            logger.warning(f'SKIP - Activate Cloudlet on {network.upper()}')
+        else:
+            cmd = self.build_cmd()
+            if network == 'STAGING':
+                cmd = f'{cmd} activate --policy {onboard.cloudlet_policy} --network staging --version {version}'
+            if network == 'PRODUCTION':
+                cmd = f'{cmd} activate --policy {onboard.cloudlet_policy} --network production --version {version}'
+            command = cmd.split(' ')
+            logger.debug(cmd)
+            act_cloudlet_cli = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            stdout, stderr = act_cloudlet_cli.communicate()
+            print(stdout.decode('utf-8'))
+            logger.warning(f'Successfully activated Cloudlet configuration to Akamai {network} network')  
+
+
     def update_phasedrelease_rule(self,
                                   rules: dict,
                                   rulename: str,

--- a/bin/utility.py
+++ b/bin/utility.py
@@ -2041,10 +2041,7 @@ class Cloudlets:
             logger.warning(f'SKIP - Activate Cloudlet on {network.upper()}')
         else:
             cmd = self.build_cmd()
-            if network == 'STAGING':
-                cmd = f'{cmd} activate --policy {onboard.cloudlet_policy} --network staging --version {version}'
-            if network == 'PRODUCTION':
-                cmd = f'{cmd} activate --policy {onboard.cloudlet_policy} --network production --version {version}'
+            cmd = f'{cmd} activate --policy {onboard.cloudlet_policy} --network  {network.lower()} --version {version}'
             command = cmd.split(' ')
             logger.debug(cmd)
             act_cloudlet_cli = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)


### PR DESCRIPTION
The function activate_policy only activated changes to staging but this version of code has a new method to activate both on staging and production, when we are trying to do a custom delete.

Chnages have been done to 2 files
Utility.py: Added a new function activate_policy_for_customdelete(self, onboard, version: int, network: str):
akamai-onboard.py: changes done to activate version on staging and prod based on flag set.