### PR TITLE
Aug15-update functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,12 +542,12 @@ www.example-3.com,2222222
 
 # custom
 
-Update delivery config + cloudlet policy + waf
+Add PATH from rules | Update delivery config + cloudlet policy + waf
 
 ```bash
 Options:
   --env                environment JSON file  [required]
-  --csv                csv file with headers "path,propertyName"  [required]
+  --csv                csv file with headers "path"  [required]
   --build-env          environment to build  [default: dev; required]
   --property-version   property version to build from network.  options: prod,
                        staging, latest, or numeric value  [default: prod]
@@ -580,12 +580,12 @@ akamai onboard -s default custom --env environments.json --csv batch-create.csv 
 
 # custom_update
 
-Update delivery config + cloudlet policy + WAF for curated rules in PM
+Update PATH from rules | Update delivery config + cloudlet policy + WAF for curated rules in PM
 
 ```bash
   Options:
   --env                environment JSON file  [required]
-  --csv                csv file with headers "path,propertyName"  [required]
+  --csv                csv file with headers "path,updated_path"  [required]
   --build-env          environment to build  [default: dev; required]
   --property-version   property version to build from network.  options: prod,
                        staging, latest, or numeric value  [default: prod]
@@ -594,6 +594,46 @@ Update delivery config + cloudlet policy + WAF for curated rules in PM
 
   --use-cpcode         override creating new cpcode for each new path, provide
                        valid existing numeric value
+
+  --dryrun             validate only  [default: False]
+
+  --note               property version note  [default: Onboard CLI custom]
+
+```
+
+```mermaid
+flowchart LR
+    A[fill environment detail into JSON file] --> B[populate paths into CSV file]
+    B-->C[run akamai onboard custom_update to update the entries for curated setup]
+    C-->D[update delivery configuration, cloudlet policy, and WAF match target]
+```
+
+### Usage
+
+- Sample csv and json file are in templates/sample_custom folder
+
+```bash
+
+akamai onboard -s default custom_update --env environments.json --csv batch-update.csv --build-env prod
+
+akamai onboard -s default custom_update --env environments.json --csv batch-update.csv --build-env dev \
+    --property-version staging --dryrun
+
+```
+
+# custom_delete
+
+Remove PATH from rules | Update delivery config + cloudlet policy + WAF for curated rules in PM
+
+```bash
+  Options:
+  --env                environment JSON file  [required]
+  --csv                csv file with headers "path"  [required]
+  --build-env          environment to build  [default: dev; required]
+  --property-version   property version to build from network.  options: prod,
+                       staging, latest, or numeric value  [default: prod]
+
+  --email              email(s) for activation notifications
 
   --dryrun             validate only  [default: False]
 

--- a/README.md
+++ b/README.md
@@ -578,13 +578,12 @@ akamai onboard -s default custom --env environments.json --csv batch-create.csv 
     --property-version staging --use-cpcode 111111 --dryrun
 ```
 
+# custom_update
 
-# custom_delete
-
-Remove path matches from delivery config + cloudlet policy + waf for curated rules in PM
+Update delivery config + cloudlet policy + WAF for curated rules in PM
 
 ```bash
-Options:
+  Options:
   --env                environment JSON file  [required]
   --csv                csv file with headers "path,propertyName"  [required]
   --build-env          environment to build  [default: dev; required]
@@ -593,14 +592,20 @@ Options:
 
   --email              email(s) for activation notifications
 
+  --use-cpcode         override creating new cpcode for each new path, provide
+                       valid existing numeric value
+
   --dryrun             validate only  [default: False]
+
+  --note               property version note  [default: Onboard CLI custom]
 
 ```
 
 ```mermaid
 flowchart LR
     A[fill environment detail into JSON file] --> B[populate paths into CSV file]
-    B-->C[run akamai onboard custom_delete to delete he entries for curated setup]
+    B-->C[run akamai onboard custom_update to update the entries for curated setup]
+    C-->D[update delivery configuration, cloudlet policy, and WAF match target]
 ```
 
 ### Usage
@@ -609,9 +614,9 @@ flowchart LR
 
 ```bash
 
-akamai onboard -s default custom_delete --env environments.json --csv batch-delete.csv --build-env prod
+akamai onboard -s default custom_update --env environments.json --csv batch-update.csv --build-env prod
 
-akamai onboard -s default custom_delete --env environments.json --csv batch-delete.csv --build-env dev \
+akamai onboard -s default custom_update --env environments.json --csv batch-update.csv --build-env dev \
     --property-version staging --dryrun
 
 ```

--- a/bin/akamai-onboard.py
+++ b/bin/akamai-onboard.py
@@ -1448,7 +1448,7 @@ def custom_update(config, **kwargs):
             for path in set(map(lambda x: x['path_match'].strip(), onboard.paths)):
                 logger.info(f"Replaced Cloudlet path: {path}")
             logger.debug('Updating Cloudlet Policy after path removal')
-            
+
             version_number = uc.create_cloudlet_policy_version(
                 onboard.cloudlet_policy,
                 replaced_rules["matchRules"],
@@ -1471,7 +1471,7 @@ def custom_update(config, **kwargs):
 
     end_time = time.perf_counter()
     elapse_time = str(strftime('%H:%M:%S', gmtime(end_time - start_time)))
-    logger.info(f'TOTAL DURATION: {elapse_time}, End Akamai CLI delete process')
+    logger.info(f'TOTAL DURATION: {elapse_time}, End Akamai CLI update process')
 
 
 def get_prog_name():

--- a/bin/akamai-onboard.py
+++ b/bin/akamai-onboard.py
@@ -48,6 +48,7 @@ from model.appsec import Property
 from model.multi_hosts import MultiHosts
 from model.single_host import SingleHost
 from tabulate import tabulate
+import re
 
 
 
@@ -1172,9 +1173,13 @@ def custom_delete(config, **kwargs):
         util_papi = utility_papi.papiFunctions()
         property_rule_tree = util_papi.custom_property_version(onboard, wrapper, util)
         paths_to_delete = set(path['path_match'].strip() for path in onboard.paths)
-        rulenames_to_delete = set(path['rulename'].strip() for path in onboard.paths)
-
-        
+        # Extract rulename from path_match using your pattern logic
+        pattern = r'/([^/-]+)-'
+        rulenames_to_delete = {
+            re.search(pattern, p).group(1).upper()
+            for p in paths_to_delete
+            if re.search(pattern, p)
+        }
 
         logger.info(f'Looking to delete rules for {len(paths_to_delete)} paths and {len(rulenames_to_delete)} rulenames.')
         logger.info(f"Paths to delete (WAF + Cloudlet): {paths_to_delete}")
@@ -1298,7 +1303,175 @@ def custom_delete(config, **kwargs):
     elapse_time = str(strftime('%H:%M:%S', gmtime(end_time - start_time)))
     logger.info(f'TOTAL DURATION: {elapse_time}, End Akamai CLI delete process')
 
+@cli.command(name='custom_update',short_help='Custom update command using account switch key')
+@click.option('--env',         metavar='', required=True, help='Path to environment JSON file')
+@click.option('--csv',         metavar='', required=True, help='Path to input CSV file')
+@click.option('--build-env',   metavar='', required=True, default='dev', show_default=True,help='Which environment in the JSON to build (e.g. dev, prod)')
+@click.option('--property-version', metavar='', default='prod', show_default=True,help='Base property version to update from (options: prod, staging, latest, or numeric)')
+@click.option('--email',       metavar='', multiple=True,help='Email(s) for activation notifications')
+@click.option('--dryrun',      is_flag=True, default=False, show_default=True,help='Validate only, don’t actually perform updates')
+@click.option('--note',        metavar='', default='Update paths CLI', show_default=True,help='Property version note')
+@pass_config
+def custom_update(config, **kwargs):
+    """
+    Delete entries from delivery config + cloudlet policy + WAF
+    """
+    logger.info('Start Akamai CLI update process')
+    _, wrapper = init_config(config)
+    start_time = time.perf_counter()
 
+    # Verify required Akamai CLI components
+    util = utility.utility()
+    if not all([
+        util.installedCommandCheck('akamai'),
+        util.executeCommand(['akamai', 'pipeline']),
+        util.executeCommand(['akamai', 'cloudlets'])
+        
+    ]):
+        logger.info("into all")
+        sys.exit()
+
+    # Load onboarding config and parse CSV
+    onboard = onboard_custom.OnboardCustomUpdate(config, kwargs, util)
+    result = util.validateCustomSteps(onboard, wrapper)
+    logger.debug(f"✅ validateCustomSteps returned: {result}")
+
+    if result:
+        util_papi = utility_papi.papiFunctions()
+        logger.info(f"into util_papi: {util_papi}")
+        property_rule_tree = util_papi.custom_property_version(onboard, wrapper, util)
+        update_from_paths   = { p['path_match']      for p in onboard.paths_update}
+        update_to_paths     = { p['path_update_to']  for p in onboard.paths_update }
+
+        # and derive your rule-names from the paths:
+        rulenames_to_update = {r['rulename'] for r in onboard.paths_update if r.get('rulename')}      
+        logger.info(f"Rule update from PM in Progress: {rulenames_to_update}")
+        logger.info(f"PM + WAF + Cloudlet: Paths will be updated from: {update_from_paths} tp {update_to_paths}")
+        rules_modified = util_papi.update_rules_from_property_tree(property_rule_tree['rules'], rulenames_to_update, update_from_paths,update_to_paths)
+
+        if not rules_modified:
+            logger.warning('No matching rules found to remove.')
+            sys.exit(0)    
+
+        #Handle Property Manager
+        print('\n\n')
+        logger.warning('Updating Property Manager')
+        logger.info(f"Rule updation from PM in Progress: {rulenames_to_update}")
+        onboard.updated_property_rule_tree = property_rule_tree['rules']
+        util_papi.update_custom_property(onboard, wrapper, property_rule_tree['ruleFormat'])
+        logger.info(f'New property version: v{onboard.updated_property_version} is based on v{onboard.property_version_base}')
+
+        print()
+        property = [{'propertyName': onboard.property_name, 'propertyId': property_rule_tree['propertyId']}]
+
+        if not onboard.activate_property_staging:
+            staging_act_id = 0
+            logger.warning('SKIP - Activate delivery configuration on STAGING')
+        else:
+            _, _, fail, act = util_papi.batch_activate_and_poll(wrapper,
+                                                            property,
+                                                            onboard.contract_id,
+                                                            onboard.group_id,
+                                                            version=onboard.updated_property_version,
+                                                            network='STAGING',
+                                                            emailList=onboard.notification_emails,
+                                                            notes=onboard.property_version_note)
+            staging_act_id = act[0]['activationId'] if len(fail) == 0 else fail[0]['activationId']
+
+        if not onboard.activate_property_production:
+            prod_act_id = 0
+            logger.warning('SKIP - Activate delivery configuration on PRODUCTION')
+        else:
+            _, _, fail, act = util_papi.batch_activate_and_poll(wrapper,
+                                                                property,
+                                                                onboard.contract_id,
+                                                                onboard.group_id,
+                                                                version=onboard.updated_property_version,
+                                                                network='PRODUCTION',
+                                                                emailList=onboard.notification_emails,
+                                                                notes=onboard.property_version_note)
+            prod_act_id = act[0]['activationId'] if len(fail) == 0 else fail[0]['activationId']
+
+        
+        #Handle Security Config
+        print('\n\n')
+        logger.warning('Updating WAF - removing match targets')
+        util_waf = utility_waf.wafFunctions()
+        if not util_waf.createWafVersionfordelete(wrapper, onboard, notes=onboard.version_notes):
+            logger.error('Failed to create WAF version')
+            sys.exit()
+        wrapper.update_waf_config_version_note(onboard, notes=onboard.version_notes)
+        logger.info(f"Replacing WAF paths:\n  from: {update_from_paths}\n    to: {update_to_paths}")
+
+        # 3) call your new replace function
+        replace_result = util_waf.replacingMatchTargetPaths(
+            wrapper,
+            update_from_paths,
+            update_to_paths,
+            onboard.onboard_waf_config_id,
+            onboard.onboard_waf_config_version,
+            onboard.waf_match_target_id
+        )
+
+        if replace_result:
+            logger.info('WAF match‐target paths successfully replaced.')
+        else:
+            logger.error('Failed to replace one or more WAF match‐target paths.')
+
+        if onboard.activate_waf_staging:
+            util_waf.activateAndPoll(wrapper, onboard, network='STAGING')
+        else:
+            logger.warning('SKIP - Activate WAF config on STAGING')
+
+        if onboard.activate_property_production:
+            util_waf.activateAndPoll(wrapper, onboard, network='PRODUCTION')
+        else:
+            logger.warning('SKIP - Activate WAF config on PRODUCTION')
+
+
+        #Handle Cloudlet Config
+        print('\n\n')
+        logger.warning('Updating Cloudlet Policy - replacing path matches')
+        uc = utility.Cloudlets(config)
+        uc.retrieve_matchrules(onboard.cloudlet_policy)
+        cloudlet_rules = load_json('policy_matchrules.json')
+        #logger.info(f'cloudlet_rules: {cloudlet_rules}')
+        if not cloudlet_rules:
+            logger.error("❌ Failed to load cloudlet_rules from policy_matchrules.json")
+            return
+        
+        logger.debug("🦪 Scanning cloudlet_rules for 'Property'")
+        logger.debug(json.dumps(cloudlet_rules, indent=2))   
+
+        replaced, replaced_rules = uc.replace_phasedrelease_paths(cloudlet_rules, onboard,update_from_paths,update_to_paths)
+        if replaced:
+            for path in set(map(lambda x: x['path_match'].strip(), onboard.paths)):
+                logger.info(f"Replaced Cloudlet path: {path}")
+            logger.debug('Updating Cloudlet Policy after path removal')
+            
+            version_number = uc.create_cloudlet_policy_version(
+                onboard.cloudlet_policy,
+                replaced_rules["matchRules"],
+                onboard.version_notes
+            )
+            #uc.activate_policy_for_customdelete(onboard, version_number, network='STAGING')
+            #uc.activate_policy_for_customdelete(onboard, version_number, network='PRODUCTION')
+
+            if onboard.activate_cloudlet_staging:
+                uc.activate_policy_for_customdelete(onboard, version_number, network='STAGING')
+            else:
+                logger.warning('SKIP - Activate cloudlet config on STAGING')
+
+            if onboard.activate_cloudlet_production:
+                uc.activate_policy_for_customdelete(onboard, version_number, network='PRODUCTION')
+            else:
+                logger.warning('SKIP - Activate cloudlet config on PRODUCTION')
+        else:
+            logger.warning('No cloudlet paths removed or no update needed')   
+
+    end_time = time.perf_counter()
+    elapse_time = str(strftime('%H:%M:%S', gmtime(end_time - start_time)))
+    logger.info(f'TOTAL DURATION: {elapse_time}, End Akamai CLI delete process')
 
 
 def get_prog_name():

--- a/bin/onboard_custom.py
+++ b/bin/onboard_custom.py
@@ -39,6 +39,7 @@ class Onboard:
             self.valid_csv = True
             self.valid_env = True
             self.paths = util.csv_2_path_array(self.csv_loc)
+            self.paths_update = []
             self.property_version = click_args['property_version']
             self.property_version_note = click_args['note']
             self.cloudlet_policy = self.env_details[self.build_env]['cloudlet_policy']
@@ -72,3 +73,13 @@ class Onboard:
             return abs_file_location
         else:
             exit(logger.error(f'File not found {abs_file_location}'))
+
+class OnboardCustomUpdate(Onboard):
+    """Update flow: modify existing rules"""
+    def __init__(self, config, click_args: dict, util):
+        super().__init__(config, click_args, util)
+        self.paths_update = util.csv_2_pathToUpdate_array(self.csv_loc)
+
+    @property
+    def input_paths(self):
+        return self.paths_update

--- a/bin/utility.py
+++ b/bin/utility.py
@@ -2235,13 +2235,15 @@ class Cloudlets:
             [p.strip() for p in update_to_paths]
         ))
         logger.debug(f"Calling replace_phasedrelease_paths with map: {replace_map}")
+        did_replace = False          # <-- ensure defined for all code paths
+        updated_rules = None         # <-- sentinel to know if we found 'Property'
 
         # 2) Locate the 'Property' rule
         for rule in cloudlet_rules.get('matchRules', []):
             if rule.get('name', '').strip().lower() == 'property':
                 matches = rule.get('matches', [])
                 new_matches = []
-                did_replace = False
+                #did_replace = False
 
                 # 3) Iterate and replace path values
                 for match in matches:
@@ -2267,11 +2269,18 @@ class Cloudlets:
                     "matchRuleFormat": "1.0",
                     "matchRules": cloudlet_rules.get('matchRules', [])
                 }
+                break  # done; we found and processed the Property rule
+                
+            #logger.debug(f"Replacements applied? {did_replace}")
+            #logger.debug(json.dumps(updated_rules, indent=2))
+            #return did_replace, updated_rules
 
+        # Log/return only if we actually touched the Property rule
+        if updated_rules is not None:
             logger.debug(f"Replacements applied? {did_replace}")
             logger.debug(json.dumps(updated_rules, indent=2))
             return did_replace, updated_rules
-
+        
         logger.warning('Rule "Property" not found in Cloudlet Policy')
         return False, {}
 

--- a/bin/utility.py
+++ b/bin/utility.py
@@ -1433,6 +1433,30 @@ class utility:
         except FileNotFoundError as err:
             logger.error(err)
         return paths
+    
+    
+    def csv_2_pathToUpdate_array(self, filepath: str) -> list:
+        paths = []
+        try:
+            with open(filepath, encoding='utf-8-sig', newline='') as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    old = row['path'].strip()
+                    new = row['updated_path'].strip()
+
+                    # Same extraction logic as csv_2_path_array
+                    # Grab the token before the first '-' in the segment after a '/'
+                    m = re.search(r'/([^/-]+)-', old)
+                    rulename = m.group(1).upper() if m else None
+                    logger.info(f"rulename is....... {rulename}")
+                    paths.append({
+                        'path_match':     old,     # original path to replace
+                        'path_update_to': new,     # new path
+                        'rulename':       rulename # e.g., 'AGPRHQQ' from '/en/hotels/agprhqq-.../'
+                    })
+        except FileNotFoundError as err:
+            logger.error(err)
+        return paths
 
     def validate_group_id(self, onboard, groups) -> None:
         for group in groups:
@@ -2030,7 +2054,7 @@ class Cloudlets:
             stdout, stderr = act_cloudlet_cli.communicate()
             print(stdout.decode('utf-8'))
 
-    def activate_policy_for_customdelete(self, onboard, version: int, network: str):
+    def activate_policy_for_customdelete1(self, onboard, version: int, network: str):
         activation = False
         if network == 'STAGING':
             activation = onboard.activate_cloudlet_staging
@@ -2041,13 +2065,43 @@ class Cloudlets:
             logger.warning(f'SKIP - Activate Cloudlet on {network.upper()}')
         else:
             cmd = self.build_cmd()
-            cmd = f'{cmd} activate --policy {onboard.cloudlet_policy} --network  {network.lower()} --version {version}'
+            #cmd = f'{cmd} activate --policy {onboard.cloudlet_policy} --network  {network.lower()} --version {version}'
+            
+            if network == 'STAGING':
+                cmd = f'{cmd} activate --policy {onboard.cloudlet_policy} --network  staging --version {version}'
+            if network == 'PRODUCTION':
+                cmd = f'{cmd} activate --policy {onboard.cloudlet_policy} --network  production --version {version}'
+
             command = cmd.split(' ')
             logger.debug(cmd)
             act_cloudlet_cli = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             stdout, stderr = act_cloudlet_cli.communicate()
             print(stdout.decode('utf-8'))
             logger.warning(f'Successfully activated Cloudlet configuration to Akamai {network} network')  
+
+    def activate_policy_for_customdelete(self, onboard, version: int, network: str):
+        if network == 'STAGING' and onboard.activate_cloudlet_staging:
+            cmd = self.build_cmd()
+            cmd += f' activate --policy {onboard.cloudlet_policy} --network staging --version {version}'
+        elif network == 'PRODUCTION' and onboard.activate_cloudlet_production:
+            cmd = self.build_cmd()
+            cmd += f' activate --policy {onboard.cloudlet_policy} --network production --version {version}'
+        else:
+            logger.warning(f'SKIP - Activate Cloudlet on {network.upper()}')
+            return
+
+        command = cmd.split(' ')  # Using plain split
+        logger.debug(f'Running command: {cmd}')
+
+        act_cloudlet_cli = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        stdout, _ = act_cloudlet_cli.communicate()
+        output = stdout.decode('utf-8')
+        print(output)
+
+        if act_cloudlet_cli.returncode == 0:
+            logger.warning(f'Successfully activated Cloudlet configuration to Akamai {network.upper()} network')
+        else:
+            logger.error(f'Failed to activate Cloudlet on {network.upper()}. Output:\n{output}')
 
 
     def update_phasedrelease_rule(self,
@@ -2166,6 +2220,57 @@ class Cloudlets:
                 logger.debug(f"Value of 'updated' after removal attempt: {removed_any}")
                 logger.debug(json.dumps(updated_rules, indent=2))
                 return removed_any, updated_rules
+
+        logger.warning('Rule "Property" not found in Cloudlet Policy')
+        return False, {}
+    
+    def replace_phasedrelease_paths(self, cloudlet_rules: dict, onboard, update_from_paths: list, update_to_paths: list) -> tuple[bool, dict]:
+        """
+        Replace path match entries in the Cloudlet rule named 'Property'.
+        Returns a tuple (did_replace_flag, updated_rules_dict).
+        """
+        # 1) Build a mapping old_path → new_path
+        replace_map = dict(zip(
+            [p.strip() for p in update_from_paths],
+            [p.strip() for p in update_to_paths]
+        ))
+        logger.debug(f"Calling replace_phasedrelease_paths with map: {replace_map}")
+
+        # 2) Locate the 'Property' rule
+        for rule in cloudlet_rules.get('matchRules', []):
+            if rule.get('name', '').strip().lower() == 'property':
+                matches = rule.get('matches', [])
+                new_matches = []
+                did_replace = False
+
+                # 3) Iterate and replace path values
+                for match in matches:
+                    if match.get('matchType') == 'path':
+                        values = match.get('matchValue', '').split()
+                        replaced_values = []
+                        for v in values:
+                            original = v.strip()
+                            if original in replace_map:
+                                replaced_values.append(replace_map[original])
+                                did_replace = True
+                            else:
+                                replaced_values.append(original)
+                        if replaced_values:
+                            match['matchValue'] = ' '.join(replaced_values)
+                            new_matches.append(match)
+                    else:
+                        new_matches.append(match)
+
+                # 4) Build updated rules payload
+                rule['matches'] = new_matches
+                updated_rules = {
+                    "matchRuleFormat": "1.0",
+                    "matchRules": cloudlet_rules.get('matchRules', [])
+                }
+
+            logger.debug(f"Replacements applied? {did_replace}")
+            logger.debug(json.dumps(updated_rules, indent=2))
+            return did_replace, updated_rules
 
         logger.warning('Rule "Property" not found in Cloudlet Policy')
         return False, {}

--- a/bin/utility_papi.py
+++ b/bin/utility_papi.py
@@ -558,3 +558,41 @@ class papiFunctions:
 
         _walk_and_remove(rule_node)
         return rules_modified
+    
+    
+    def update_rules_from_property_tree(self,rule_node: dict,rulenames_to_update: set,update_from_paths: set,update_to_paths: set) -> bool:
+            """
+            Recursively updates 'path' criteria in rules whose names are in
+            rulenames_to_update, swapping any values in update_from_paths for
+            the corresponding entry in update_to_paths.
+            Returns True if any criteria were updated, False otherwise.
+            """
+            rules_modified = False
+            # build a one-to-one mapping from old to new paths
+            path_map = dict(zip(update_from_paths, update_to_paths))
+
+            def _walk_and_update(node):
+                nonlocal rules_modified
+                for child in node.get('children', []):
+                    logger.debug(f"Walking rule: {child['name']}")
+                    if child.get('name', '').strip() in rulenames_to_update:
+                        logger.debug(f"Evaluating rule for updating: {child['name']}")
+                        for crit in child.get('criteria', []):
+                            if crit.get('name') == 'path':
+                                opts = crit.setdefault('options', {})
+                                # single-value case
+                                val = opts.get('value')
+                                if val in path_map:
+                                    opts['value'] = path_map[val]
+                                    rules_modified = True
+                                # multi-value case
+                                if 'values' in opts:
+                                    new_vals = [ path_map.get(v, v) for v in opts['values'] ]
+                                    if new_vals != opts['values']:
+                                        opts['values'] = new_vals
+                                        rules_modified = True
+                    # recurse into grandchildren
+                    _walk_and_update(child)
+
+            _walk_and_update(rule_node)
+            return rules_modified

--- a/bin/utility_waf.py
+++ b/bin/utility_waf.py
@@ -5,6 +5,7 @@ import json
 import re
 import sys
 import time
+import wrapper_api
 from time import gmtime
 from time import strftime
 
@@ -483,4 +484,60 @@ class wafFunctions:
                 return False
         else:
             logger.error(json.dumps(match_target_response.json(), indent=4))
+            return False
+        
+    def replacingMatchTargetPaths(self, wrapper_object,
+                              path_list_from, path_list_to,
+                              config_id, version, target_id):
+        """
+        Fetches the WAF match target configuration, replaces specified file paths,
+        and applies the update back to the target.
+
+        :param wrapper_object: API client wrapper with getMatchTarget and modifyMatchTarget
+        :param path_list_from: List of file paths to replace
+        :param path_list_to:   List of corresponding new file paths
+        :param config_id:      WAF configuration ID
+        :param version:        Configuration version to modify
+        :param target_id:      Match target ID within the configuration
+        :return: True if replacement and update succeeded, False otherwise
+        """
+        # 1. Retrieve current match-target configuration
+        response = wrapper_object.getMatchTarget(config_id, version, target_id)
+        if not response.ok:
+            logger.error("Failed to fetch WAF match target: %s", response.status_code)
+            logger.debug(json.dumps(response.json(), indent=4))
+            return False
+
+        data = response.json()
+
+        # 2. Preserve original filePaths order
+        original_paths = data.get('filePaths', [])
+        logger.debug("Original WAF filePaths: %s", original_paths)
+
+        # 3. Build precise replacement map
+        if len(path_list_from) != len(path_list_to):
+            logger.error("Mismatched lengths: from=%d, to=%d", len(path_list_from), len(path_list_to))
+            return False
+        replace_map = {old: new for old, new in zip(path_list_from, path_list_to)}
+        logger.debug("Replacement map: %s", replace_map)
+
+        # 4. Apply replacements
+        updated_paths = [replace_map.get(fp, fp) for fp in original_paths]
+        if updated_paths == original_paths:
+            logger.warning("No matching paths found in WAF match target to replace.")
+            return False
+
+        # 5. Commit updated paths
+        data['filePaths'] = updated_paths
+        #logger.info("Applying updated filePaths: %s", updated_paths)
+
+        modify_response = wrapper_object.modifyMatchTarget(
+            config_id, version, target_id, json.dumps(data)
+        )
+        if modify_response.ok:
+            logger.info("Successfully replaced match-target paths.")
+            return True
+        else:
+            logger.error("Failed to modify match target: %s", modify_response.status_code)
+            logger.debug(json.dumps(modify_response.json(), indent=4))
             return False

--- a/templates/sample_custom/batch-delete.csv
+++ b/templates/sample_custom/batch-delete.csv
@@ -1,0 +1,2 @@
+﻿path
+/en/hotels/agprhqq1-higueron-hotel-malaga/

--- a/templates/sample_custom/batch-update.csv
+++ b/templates/sample_custom/batch-update.csv
@@ -1,0 +1,2 @@
+﻿path,updated_path
+/en/hotels/agprhqq2-higueron-hotel-malaga/,/en/hotels/agprhqq2-higueron-hotel-malaga-old/


### PR DESCRIPTION
Introduces custom_update CLI to replace path matches (from → to) across Property Manager, WAF match targets, and Cloudlet policies via CSV, with full account switch key support.

Derives rulenames from CSV, updates PM ruletree via update_rules_from_property_tree, and swaps WAF/Cloudlet paths using replacingMatchTargetPaths and replace_phasedrelease_paths, with validation and --dryrun.

Optional staging/production activation and version notes; existing commands/flows remain unchanged.